### PR TITLE
Add spacing feature to pos analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 build/
 dist/
 docs/_build/
+.idea/

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - pip install -r requirements-py3.txt --use-mirrors
+    - pip install -r requirements-py3.txt
     - pip install coveralls
     - pip install pytest-cov
     - python setup.py -q install

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  python:
+    version: 3.6.0
+
+dependencies:
+  override:
+    - pip install -r requirements-py3.txt --use-mirrors
+    - pip install coveralls
+    - pip install pytest-cov
+    - python setup.py -q install
+
+test:
+  override:
+    - coverage run --source=konlpy -m py.test -k 'not (komoran or mecab)'

--- a/konlpy/jvm.py
+++ b/konlpy/jvm.py
@@ -48,6 +48,6 @@ def init_jvm(jvmpath=None):
     if jvmpath:
         jpype.startJVM(jvmpath, '-Djava.class.path=%s' % classpath,
                                 '-Dfile.encoding=UTF8',
-                                '-ea', '-Xmx768m')
+                                '-ea', '-Xmx2g')
     else:
         raise ValueError("Please specify the JVM path.")

--- a/konlpy/tag/_kkma.py
+++ b/konlpy/tag/_kkma.py
@@ -8,7 +8,6 @@ import jpype
 from .. import jvm
 from .. import utils
 
-
 __all__ = ['Kkma']
 
 
@@ -46,7 +45,7 @@ class Kkma():
         if not nouns: return []
         return [nouns.get(i).getString() for i in range(nouns.size())]
 
-    def pos(self, phrase, flatten=True):
+    def pos(self, phrase, flatten=True, space=False):
         """POS tagger.
 
         :param flatten: If False, preserves eojeols."""
@@ -66,7 +65,10 @@ class Kkma():
                         morphemes.append((morpheme.getString(), morpheme.getTag()))
                 else:
                     morphemes.append([(eojeol.get(k).getString(), eojeol.get(k).getTag())
-                                     for k in range(eojeol.size())])
+                                      for k in range(eojeol.size())])
+
+        if space is True:
+            return self.__spacing(sentence=phrase, pos_result=morphemes)
 
         return morphemes
 
@@ -81,6 +83,25 @@ class Kkma():
         sentences = self.jki.morphAnalyzer(phrase)
         if not sentences: return []
         return [sentences.get(i).getSentence() for i in range(sentences.size())]
+
+    def __spacing(self, sentence: str, pos_result: list):
+
+        """ __spacing(sentence, pos_result)
+        insert space_tuple (" ", "Space") into pos_result to preserver space character
+
+        :param sentence: origin sentence (before pos analysis)
+        :param pos_result: pos analysis result with self.pos(***)
+        """
+
+        sentence_index = 0
+        tuple_index = 0
+
+        for text, pos in pos_result:
+            sentence_index += len(text)
+            tuple_index += 1
+            if len(sentence) > sentence_index and sentence[sentence_index] == " ":
+                pos_result.insert(tuple_index, (" ", "Space"))
+        return pos_result
 
     def __init__(self, jvmpath=None):
         if not jpype.isJVMStarted():

--- a/konlpy/tag/_komoran.py
+++ b/konlpy/tag/_komoran.py
@@ -49,15 +49,20 @@ class Komoran():
     :param dicpath: The path of dictionary files. The KOMORAN system dictionary is loaded by default.
     """
 
-    def pos(self, phrase, flatten=True):
+    def pos(self, phrase, flatten=True, space=True):
         """POS tagger.
 
-        :param flatten: If False, preserves eojeols."""
+        :param flatten: If False, preserves eojeols.
+        :param space: If True, return tokens with space character
+        """
 
         if sys.version_info[0] < 3:
             result = self.jki.analyzeMorphs(phrase, self.dicpath)
         else:
             result = self.jki.analyzeMorphs3(phrase, self.dicpath).toString()
+
+        if space is True:
+            return self.__spacing(sentence=phrase, pos_result=parse(result, flatten))
 
         return parse(result, flatten)
 
@@ -71,6 +76,25 @@ class Komoran():
         """Parse phrase to morphemes."""
 
         return [s for s, t in self.pos(phrase)]
+
+    def __spacing(self, sentence: str, pos_result: list):
+
+        """ __spacing(sentence, pos_result)
+        insert space_tuple (" ", "Space") into pos_result to preserver space character
+
+        :param sentence: origin sentence (before pos analysis)
+        :param pos_result: pos analysis result with self.pos(***)
+        """
+
+        sentence_index = 0
+        tuple_index = 0
+
+        for text, pos in pos_result:
+            sentence_index += len(text)
+            tuple_index += 1
+            if len(sentence) > sentence_index and sentence[sentence_index] == " ":
+                pos_result.insert(tuple_index, (" ", "Space"))
+        return pos_result
 
     def __init__(self, jvmpath=None, dicpath=None):
         if not jpype.isJVMStarted():

--- a/konlpy/tag/_twitter.py
+++ b/konlpy/tag/_twitter.py
@@ -34,7 +34,7 @@ class Twitter():
     :param jvmpath: The path of the JVM passed to :py:func:`.init_jvm`.
     """
 
-    def pos(self, phrase, norm=False, stem=False):
+    def pos(self, phrase, norm=False, stem=False, space=False):
         """POS tagger.
         In contrast to other classes in this subpackage,
         this POS tagger doesn't have a `flatten` option,
@@ -43,13 +43,20 @@ class Twitter():
 
         :param norm: If True, normalize tokens.
         :param stem: If True, stem tokens.
+        :param space: If True, return tokens with space character
         """
 
         tokens = self.jki.tokenize(
-                    phrase,
-                    jpype.java.lang.Boolean(norm),
-                    jpype.java.lang.Boolean(stem)).toArray()
-        return [tuple(t.rsplit('/', 1)) for t in tokens]
+            phrase,
+            jpype.java.lang.Boolean(norm),
+            jpype.java.lang.Boolean(stem)).toArray()
+
+        pos_result = [tuple(t.rsplit('/', 1)) for t in tokens]
+
+        if space is True:
+            return self.__spacing(sentence=phrase, pos_result=pos_result)
+
+        return pos_result
 
     def nouns(self, phrase):
         """Noun extractor."""
@@ -66,10 +73,29 @@ class Twitter():
         """Phrase extractor."""
 
         return [p for p in self.jki.phrases(phrase).toArray()]
-    
+
     def normalize(self, phrase):
         text = self.jki.normalize(phrase)
         return text
+
+    def __spacing(self, sentence: str, pos_result: list):
+
+        """ __spacing(sentence, pos_result)
+        insert space_tuple (" ", "Space") into pos_result to preserver space character
+
+        :param sentence: origin sentence (before pos analysis)
+        :param pos_result: pos analysis result with self.pos(***)
+        """
+
+        sentence_index = 0
+        tuple_index = 0
+
+        for text, pos in pos_result:
+            sentence_index += len(text)
+            tuple_index += 1
+            if len(sentence) > sentence_index and sentence[sentence_index] == " ":
+                pos_result.insert(tuple_index, (" ", "Space"))
+        return pos_result
 
     def __init__(self, jvmpath=None):
         if not jpype.isJVMStarted():

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def requirements():
         _genver(3, range(5)): _openreq('requirements-py3.txt')
     }
 
-setup(name='konlpy',
+setup(name='atlasguide-konlpy',
     version=__version__,
     description='Python package for Korean natural language processing.',
     long_description="""\

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def requirements():
         _genver(3, range(5)): _openreq('requirements-py3.txt')
     }
 
-setup(name='atlasguide-konlpy',
+setup(name='goodatlas-konlpy',
     version=__version__,
     description='Python package for Korean natural language processing.',
     long_description="""\


### PR DESCRIPTION
When we analyze the sentence with pos function, they delete the whole
space character automatically. So we can’t recover the origin data with
pos result. So I insert the tuple (‘ ’, “Space”) into result list to
preserve origin sentence.